### PR TITLE
 Design Dedicated "Licensing" Page Reflecting "MIT License" 

### DIFF
--- a/src/app/licensing/page.tsx
+++ b/src/app/licensing/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import Licensing from "@/components/shared/licensing";
+import Header from "@/components/shared/Header";
+import Footer from "@/components/shared/Footer";
+
+const Page = () => {
+  return (
+    <div>
+      <Header />
+      <Licensing />
+      <Footer />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -141,7 +141,7 @@ const Footer: React.FC = () => {
                 </li>
                 <li className="mb-4">
                   <a
-                    href="https://github.com/subhadeeproy3902/BloxAI/blob/main/LICENSE"
+                    href="/licensing"
                     className="hover:underline"
                   >
                     License

--- a/src/components/shared/licensing.tsx
+++ b/src/components/shared/licensing.tsx
@@ -37,6 +37,9 @@ const Licensing = () => {
           OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
           SOFTWARE.
         </p>
+        <p className="mb-4 text-muted-foreground">        
+         For more information check: <a href="https://github.com/subhadeeproy3902/BloxAI/blob/main/LICENSE"   className="hover:underline">LICENSE</a>
+        </p>
       </div>
     </div>
   );

--- a/src/components/shared/licensing.tsx
+++ b/src/components/shared/licensing.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+const Licensing = () => {
+  return (
+    <div className="min-h-[40rem] w-full pt-16 rounded-md flex justify-center flex-col antialiased relative overflow-hidden">
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <h1 className="text-3xl font-bold mb-4 text-foreground/75">
+          Licensing
+        </h1>
+        <p className="mb-4 text-muted-foreground">
+        Welcome to Blox AI, It is licensed under the MIT License. This page outlines the terms of the license and provide details on how you can  use, modify and distribute our project.
+        </p>
+        <h2 className="text-2xl font-bold mb-4 text-foreground/75">
+        MIT License
+        </h2>
+        <p className="mb-4 text-muted-foreground">
+          Copyright (c) 2024 Subhadeep Roy & Anish Biswas
+        </p>
+        <p className="mb-4 text-muted-foreground">
+          Permission is hereby granted, free of charge, to any person obtaining a copy
+          of this software and associated documentation files (the &quot;Software&quot;), to deal
+          in the Software without restriction, including without limitation the rights
+          to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+          copies of the Software, and to permit persons to whom the Software is
+          furnished to do so, subject to the following conditions:
+        </p>
+        <p className="mb-4 text-muted-foreground">
+          The above copyright notice and this permission notice shall be included in all
+          copies or substantial portions of the Software.
+        </p>
+        <p className="mb-4 text-muted-foreground">
+          THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+          IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+          FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+          AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+          LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+          OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+          SOFTWARE.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Licensing;


### PR DESCRIPTION

- fixes #419

## Description

Hey @subhadeeproy3902 

I have created a Licensing Page reflecting MIT license

![image](https://github.com/subhadeeproy3902/BloxAI/assets/101971980/5a5eb34b-1336-4d6a-b986-e6059c8935f5)

![image](https://github.com/subhadeeproy3902/BloxAI/assets/101971980/bbe5a0f1-7841-4b3d-b4ec-adcdd15d0ab5)



## Type of PR


- [x] Feature enhancement

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

